### PR TITLE
FIX: Courses.removeall sets state to object

### DIFF
--- a/src/components/courses.js
+++ b/src/components/courses.js
@@ -191,8 +191,8 @@ export default class Courses extends React.Component {
   }
   removeall = () => {
     var state = this.state;
-    state.freeblocks = [];
-    state.courses = [];
+    state.freeblocks = {};
+    state.courses = {};
     this.setState(state);
     if(this.state.window) {
       this.state.window.localStorage.setItem('courses', JSON.stringify(this.state.courses));


### PR DESCRIPTION
removeall was previously setting state.courses and state.freeblocks to
empty arrays, leaving generateSchedules unable to parse and breaking
WebStorage. This fix resets it to an empty object instead (the proper
format).